### PR TITLE
修复节点往负半轴移动导致节点不可控

### DIFF
--- a/packages/index.vue
+++ b/packages/index.vue
@@ -343,6 +343,12 @@ export default {
         .minus(origin)
         .add([conf.node.width / 2, conf.node.height / 2])
         .end
+      if (position[0] + origin[0] < conf.node.width / 2) {
+        position[0] = conf.node.width / 2 - origin[0]
+      }
+      if (position[1] + origin[1] < conf.node.height / 2) {
+        position[1] = conf.node.height / 2 - origin[1]
+      }
 
       if (this.hasMarkLine) {
         const resultList = []


### PR DESCRIPTION
对于单个节点，往左边缘或者上边缘拖动，节点会到画布外，如果节点完全拖动到画布外，很难再用鼠标拖回画布内
本次提交的改动，对以上情况做了修复：当单个节点拖动到左边缘或上边缘时，禁止其继续往画布外拖动